### PR TITLE
Patch auction dgfID with lotIdentifier

### DIFF
--- a/openregistry/convoy/convoy.py
+++ b/openregistry/convoy/convoy.py
@@ -158,12 +158,13 @@ class Convoy(object):
         LOGGER.info('Received auction {} from CDB'.format(auction_doc['id']))
 
         # Add items to CDB
-        auction_patch_data = {'data': {'items': items}}
+        auction_patch_data = {'data': {'items': items, 'dgfID': lot.lotIdentifier}}
         self.api_client.patch_resource_item(
             api_auction_doc.id, auction_patch_data
         )
-        LOGGER.info('Added {} items to auction {}'.format(len(items),
-                                                          auction_doc['id']))
+        LOGGER.info('Auction: {} was formed from lot: {} with {} items and identifier'.format(auction_doc['id'],
+                                                                                              lot.id,
+                                                                                              len(items)))
 
         # Add documents to CDB
         for document in documents:

--- a/openregistry/convoy/tests/test_convoy.py
+++ b/openregistry/convoy/tests/test_convoy.py
@@ -196,11 +196,13 @@ class TestConvoySuite(unittest.TestCase):
             'dgfID': u'Q81318b19827'
             }
         }
-        convoy.api_client.patch_resource_item(expected)
+        # convoy.api_client.patch_resource_item(expected)
 
-        convoy.prepare_auction(a_doc)
-        self.assertEqual(convoy.api_client.patch_resource_item.mock_calls[1][1][0],
-                         convoy.api_client.patch_resource_item.mock_calls[2][1][1])
+        # convoy.prepare_auction(a_doc)
+        lot = convoy._receive_lot(a_doc)
+        convoy._form_auction(lot, a_doc)
+        convoy.api_client.patch_resource_item.assert_called_with(a_doc['id'], expected)
+        convoy._activate_auction(lot, a_doc)
         self.assertEqual(convoy.documents_transfer_queue.qsize(), 2)
         convoy.lots_client.get_lot.assert_called_with(
             a_doc['merchandisingObject'])

--- a/openregistry/convoy/tests/test_convoy.py
+++ b/openregistry/convoy/tests/test_convoy.py
@@ -147,6 +147,7 @@ class TestConvoySuite(unittest.TestCase):
         lc.get_lot.return_value = munchify({
             'data': {
                 'id': a_doc['merchandisingObject'],
+                'lotIdentifier': u'Q81318b19827',
                 'status': u'verification',
                 'assets': ['580d38b347134ac6b0ee3f04e34b9770']
             }
@@ -179,6 +180,7 @@ class TestConvoySuite(unittest.TestCase):
         lc.get_lot.return_value = munchify({
             'data': {
                 'id': a_doc['merchandisingObject'],
+                'lotIdentifier': u'Q81318b19827',
                 'status': u'active.salable',
                 'assets': ['580d38b347134ac6b0ee3f04e34b9770']
             }
@@ -186,7 +188,19 @@ class TestConvoySuite(unittest.TestCase):
         items, documents = convoy._create_items_from_assets(asset_ids)
         convoy._create_items_from_assets = mock.MagicMock(return_value=(
             items, documents))
-        auction_doc = convoy.prepare_auction(a_doc)
+
+        # Needed to call mock function before prepare_auction, to
+        # check if parameted of this call and call from prepare_auction is equal
+        expected = {'data': {
+            'items': items,
+            'dgfID': u'Q81318b19827'
+            }
+        }
+        convoy.api_client.patch_resource_item(expected)
+
+        convoy.prepare_auction(a_doc)
+        self.assertEqual(convoy.api_client.patch_resource_item.mock_calls[1][1][0],
+                         convoy.api_client.patch_resource_item.mock_calls[2][1][1])
         self.assertEqual(convoy.documents_transfer_queue.qsize(), 2)
         convoy.lots_client.get_lot.assert_called_with(
             a_doc['merchandisingObject'])


### PR DESCRIPTION
Під час написання тесту до convoy.prepare_auction, для того щоб перевірити чи api_client.patch_resource_item викликається з правильними аргументам, а саме {"items": items, "dgfID":  lot.identifier} доводиться спочатку явно викликати замокану функцію patch_resource_item, а потім викликати функцію prepare_auction і перевірити чи співпадають patch_resource_item.mock_calls викликів цих функцій. Це виникає через, те що в коді функції prepare_auction потрібний мені patch_resource_item викликається перед іншим викликом тієї самої функції, а отже я не можу просто взяти і зробити patch_resource_item.assert_called_with, бо наступний виклик тої функції вносить свої аргументи з якими буде перевірятись patch_resource_item.assert_called_with.